### PR TITLE
fix: remove module property from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0-development",
   "description": "Validate, sanitize and document JSON schemas",
   "main": "dist",
-  "module": "src",
   "types": "dist/index.d.ts",
   "scripts": {
     "prettier": "prettier --write 'src/**/*.ts'",
@@ -28,8 +27,7 @@
   "author": "Gleb Bahmutov <gleb@cypress.io>",
   "license": "MIT",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@bahmutov/all-paths": "1.0.2",


### PR DESCRIPTION
`package.json` should not have `module` point at the TypeScript code. Since we only generate CommonJS output in `dist`, removed this property. Now our Webpack bundler does not crash anymore with:

```
Error: Webpack Compilation Error
/Users/gleb/git/cypress/node_modules/@cypress/schema-tools/src/fill.ts 12:9
Module parse failed: Unexpected token (12:9)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| // TODO: add types to input args
| export const fillBySchema = curry(
>   (schema: ObjectSchema, object: PlainObject): PlainObject => {
|     // @ts-ignore
|     schema = schema.properties || (schema.schema || schema.items).properties
 @ /Users/gleb/git/cypress/node_modules/@cypress/schema-tools/src/index.ts 5:0-22 5:0-22
 @ /Users/gleb/git/cypress/node_modules/@cypress/json-schemas/dist/index.js
 @ ./cypress/integration/fixtures_spec.js
 @ multi ./cypress/integration/fixtures_spec.js
```