### PR TITLE
chore(devtools): Fixed publishing to NPm from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2
 
 jobs:
   test:
+    context: services:npm-publish
     parallelism: 1
     working_directory: ~/repo
     docker:


### PR DESCRIPTION
Granted the job access to CircleCI Context with needed env var to publish to NPM